### PR TITLE
Setup docker image build/push in github action

### DIFF
--- a/.github/workflows/docker-image-build-and-push.yml
+++ b/.github/workflows/docker-image-build-and-push.yml
@@ -1,9 +1,7 @@
-name: Docker Image CI
+name: Docker Image Build and Push
 
 on:
   push:
-    branches: [ main ]
-  pull_request:
     branches: [ main ]
 
 jobs:
@@ -21,7 +19,7 @@ jobs:
         uses: docker/setup-buildx-action@v1
       -
         name: Login to DockerHub
-        uses: docker/login-action@v1 
+        uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/docker-image-build.yml
+++ b/.github/workflows/docker-image-build.yml
@@ -1,0 +1,27 @@
+name: Docker Image Build
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: false
+          tags: tehjrow/sprint-report-api:latest


### PR DESCRIPTION
This PR adds github actions that build the docker image and push it to dockerhub.
There are 2 actions.  One of them only builds on pull request, the other builds and pushes on pr merge.

### Platforms
* linux/amd64
* linux/arm64

### Dockerhub
https://hub.docker.com/r/tehjrow/sprint-report-api/tags

### Tag
* Currently just `latest`, will add release versions later