### PR TITLE
Change production app port

### DIFF
--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -6,4 +6,4 @@ services:
     environment:
       APP_KEY: '${APP_KEY}'
     ports:
-        - '80:80'
+        - '8080:80'


### PR DESCRIPTION
This PR changes the production docker containers port from `80` to `8080` so that I can setup a reverse proxy in front of it.